### PR TITLE
Added encoding when reading README.md in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 # Ahmed A. A. Osman
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
     
 REQUIREMENTS = ["numpy"]


### PR DESCRIPTION
The package currently fails to install on windows due to the following error while reading the file `README.md`

```
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\SUPR\setup.py", line 21, in <module>
          long_description = fh.read()
        File "C:\Program Files\Python39\lib\encodings\cp1252.py", line 23, in decode
          return codecs.charmap_decode(input,self.errors,decoding_table)[0]
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 5624: character maps to <undefined>
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

The error seems to be caused by the fact that the default encoding used by `open()` depends on the platform and is not `utf-8` on windows.

This PR fixes the issue by manually specifying the encoding when calling `open()`.